### PR TITLE
Fix Ansible Galaxy import errors

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -4,7 +4,5 @@ version: 0.1.0
 readme: README.md
 authors:
   - Red Hat, Inc. <nobody@redhat.com>
-license:
-  - MIT
 license_file: LICENSE
 repository: https://github.com/resource-hub-dev/rhub-ansible

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,1 @@
+requires_ansible: '>=2.9'

--- a/plugins/lookup/rhub_api.py
+++ b/plugins/lookup/rhub_api.py
@@ -51,16 +51,12 @@ _list:
 
 
 import os
-import datetime
 
-import requests
-
-from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 from ansible.utils.display import Display
 
 from ansible_collections.rhub.rhub.plugins.module_utils.rhub_api import (
-    RHubApiClient, RHubApiError
+    RHubApiClient
 )
 
 

--- a/plugins/modules/rhub_api.py
+++ b/plugins/modules/rhub_api.py
@@ -79,16 +79,10 @@ problem:
 """
 
 
-import os
-import datetime
 import json
 
-import requests
-
-from ansible.errors import AnsibleError
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.basic import env_fallback
-from ansible.module_utils._text import to_text
 
 from ansible_collections.rhub.rhub.plugins.module_utils.rhub_api import (
     RHubApiClient, RHubApiError


### PR DESCRIPTION
* The 'license' and 'license_file' keys are mutually exclusive
* 'requires_ansible' in meta/runtime.yml is mandatory, but no meta/runtime.yml found
* flake8 warnings